### PR TITLE
Add missing key in $config['language']

### DIFF
--- a/jury/index.php
+++ b/jury/index.php
@@ -32,7 +32,7 @@ require_once "../lib/jury/next_foto.php"; // prejury menue
 
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="<?php echo $config[' '];?>" dir="ltr" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="<?php echo $config['language']; ?>" dir="ltr" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title><?php echo $config['title'] . " - " . $text['jury']; ?></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
2015-10-08 12:27:37: (mod_fastcgi.c.2673) FastCGI-stderr: PHP Stack trace:
2015-10-08 12:27:37: (mod_fastcgi.c.2673) FastCGI-stderr: PHP   1. {main}() /data/project/wlm-jury-at/public_html/jury/index.php:0
2015-10-08 12:27:41: (mod_fastcgi.c.2673) FastCGI-stderr: PHP Notice:  Undefined index:   in /data/project/wlm-jury-at/public_html/jury/index.php on line 35
